### PR TITLE
api: web-socket-p3 b: added test for joining a trip

### DIFF
--- a/server/trips/tests/test_websocket.py
+++ b/server/trips/tests/test_websocket.py
@@ -287,3 +287,29 @@ class TestWebSocket:
         assert response_data['driver']['username'] == driver.username
 
         await communicator.disconnect()
+
+    async def test_driver_join_trip_group_on_connect(self, settings):
+        settings.CHANNEL_LAYERS = TEST_CHANNEL_LAYERS
+        user, access = await create_user(
+            'test.user@example.com', 'pAsswOrd', 'driver'
+        )
+        trip = await create_trip(driver=user)
+        communicator = WebsocketCommunicator(
+            application=application,
+            path=f'/taxi/?token={access}'
+        )
+        await communicator.connect()
+
+        # Send a message to the trip group
+        message = {
+            'type': 'echo.message',
+            'data': 'This is a test message for driver join trip group on connect',
+        }
+        channel_layer = get_channel_layer()
+        await channel_layer.group_send(f'{trip.id}', message=message)
+
+        # Rider receives message
+        response = await communicator.receive_json_from()
+        assert response == message
+
+        await communicator.disconnect()


### PR DESCRIPTION
This test confirms that once a driver has joined a trip (by accepting a trip request), they are added back to the trip's communication channel when they reconnect.